### PR TITLE
rename deprecated pillow constant

### DIFF
--- a/moog/observers/pil_renderer.py
+++ b/moog/observers/pil_renderer.py
@@ -110,7 +110,7 @@ class PILRenderer(abstract_observer.AbstractObserver):
                     color = tuple(list(color) + [opacity])
                     self._draw.polygon([tuple(v) for v in vertices], fill=color)
         image = self._canvas.resize(
-            self._image_size, resample=Image.ANTIALIAS)
+            self._image_size, resample=Image.LANCZOS)
 
         # PIL uses a coordinate system with the origin (0, 0) at the upper-left,
         # but our environment uses an origin at the bottom-left (i.e.


### PR DESCRIPTION
In the newest versions of `pillow`, the constant `PIL.Image.ANTIALIAS` has been removed. Starting from `pillow` [2.7.0](https://pillow.readthedocs.io/en/stable/releasenotes/2.7.0.html), `LANCZOS` became the preferred name over `ANTIALIAS`. The latter was kept around for quite some time it seems, but at some point recently has been totally removed.

With the latest version of `pillow`, I get the following error when I run the `pong` test:
```
 File "/home/me/.cache/pypoetry/virtualenvs/moog_user-THZRUDPD-py3.10/lib/python3.10/site-packages/moog/observers/pil_renderer.py", line 113, in __call__
    self._image_size, resample=Image.ANTIALIAS)
```

If I make the change in this PR directly on the installed version of `moog`, the error is fixed.

Looking at the dependencies on `pillow` using `poetry,
```
me@mycomputer:~/src/moog_user$ poetry show pillow
 name         : pillow                        
 version      : 10.0.0                        
 description  : Python Imaging Library (Fork) 

required by
 - imageio >=8.3.2
 - matplotlib >=6.2.0
 - spriteworld *
```
it looks like this change should be fine as `LANCZOS` was introduced before 8.3.2 which is the minimum version installed alongside `moog`. This means this change should not break any current users.