### PR TITLE
Two small patches for setup.py and `TaskManager()` class

### DIFF
--- a/mworks/task.py
+++ b/mworks/task.py
@@ -88,6 +88,8 @@ class TaskManager():
         else:
             raise ValueError(
                 'Unrecognized action space {}'.format(config['action_space']))
+        
+        self.complete = False
 
     def reset(self):
         """Reset environment.

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         ['moog.' + x for x in find_packages('moog')]
     ),
     install_requires=[
-        'cmake'
+        'cmake',
         'numpy==2.2.3',
         'matplotlib==3.10.0',
         'imageio==2.37.0',


### PR DESCRIPTION
I made fixes in the following two files:
1) Added a missing comma in setup.py for delineating the `cmake` package
2) Initialized self.complete explicitly in `__init__` instead of in the reset function for the `TaskManager()` that MWorks references. This protects against `pixel_buffer_expr` in `main.mwel` trying to render before `reset` is called.